### PR TITLE
implement '/' search hotkey

### DIFF
--- a/frontend/src/routes/_workspace_layout.workflow-builder.($id)/BlockPanel.tsx
+++ b/frontend/src/routes/_workspace_layout.workflow-builder.($id)/BlockPanel.tsx
@@ -250,6 +250,8 @@ interface BlockPanelHeaderProps {
   onSearchChange: (value: string) => void;
   viewMode: "default" | "compact";
   onViewModeChange: (mode: "default" | "compact") => void;
+  searchFocused: boolean;
+  setSearchFocused: (focused: boolean) => void;
 }
 
 function BlockPanelHeader({
@@ -257,11 +259,21 @@ function BlockPanelHeader({
   onSearchChange,
   viewMode,
   onViewModeChange,
-}: BlockPanelHeaderProps) {
+  searchFocused,
+  setSearchFocused,
+}: BlockPanelHeaderProps & {
+  searchFocused: boolean;
+  setSearchFocused: (focused: boolean) => void;
+}) {
   return (
     <div className="p-4 border-b border-gray-200 dark:border-gray-800">
       <h2 className="text-lg font-semibold mb-4">Blocks</h2>
-      <SearchBar searchQuery={searchQuery} onSearchChange={onSearchChange} />
+      <SearchBar
+        searchQuery={searchQuery}
+        onSearchChange={onSearchChange}
+        searchFocused={searchFocused}
+        setSearchFocused={setSearchFocused}
+      />
       <div className="flex justify-between mt-3">
         <ViewModeToggle
           viewMode={viewMode}
@@ -273,7 +285,15 @@ function BlockPanelHeader({
   );
 }
 
-export default function BlockPanel() {
+interface BlockPanelProps {
+  searchFocused: boolean;
+  setSearchFocused: (focused: boolean) => void;
+}
+
+export default function BlockPanel({
+  searchFocused,
+  setSearchFocused,
+}: BlockPanelProps) {
   const { recentlyUsed, clearRecentlyUsed } = useFlow();
   const [searchQuery, setSearchQuery] = useState("");
   const [viewMode, setViewMode] = useState<"default" | "compact">("default");
@@ -343,6 +363,8 @@ export default function BlockPanel() {
         onSearchChange={setSearchQuery}
         viewMode={viewMode}
         onViewModeChange={setViewMode}
+        searchFocused={searchFocused}
+        setSearchFocused={setSearchFocused}
       />
       <ScrollArea className="flex-grow overflow-y-auto p-3">
         <BlockSection

--- a/frontend/src/routes/_workspace_layout.workflow-builder.($id)/BlockPanel.tsx
+++ b/frontend/src/routes/_workspace_layout.workflow-builder.($id)/BlockPanel.tsx
@@ -285,15 +285,13 @@ function BlockPanelHeader({
   );
 }
 
-interface BlockPanelProps {
-  searchFocused: boolean;
-  setSearchFocused: (focused: boolean) => void;
-}
-
 export default function BlockPanel({
   searchFocused,
   setSearchFocused,
-}: BlockPanelProps) {
+}: {
+  searchFocused: boolean;
+  setSearchFocused: (focused: boolean) => void;
+}) {
   const { recentlyUsed, clearRecentlyUsed } = useFlow();
   const [searchQuery, setSearchQuery] = useState("");
   const [viewMode, setViewMode] = useState<"default" | "compact">("default");

--- a/frontend/src/routes/_workspace_layout.workflow-builder.($id)/SearchBar.tsx
+++ b/frontend/src/routes/_workspace_layout.workflow-builder.($id)/SearchBar.tsx
@@ -1,22 +1,41 @@
 import { Search } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { useEffect, useRef } from "react";
 
 interface SearchBarProps {
   searchQuery: string;
   onSearchChange: (value: string) => void;
+  searchFocused: boolean;
+  setSearchFocused: (focused: boolean) => void;
 }
 
-export function SearchBar({ searchQuery, onSearchChange }: SearchBarProps) {
+export function SearchBar({
+  searchQuery,
+  onSearchChange,
+  searchFocused,
+  setSearchFocused,
+}: SearchBarProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (searchFocused && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [searchFocused]);
+
   return (
     <div className="relative">
       <Label className="relative block">
         <Search className="absolute left-3 top-[11px] text-gray-400 h-4 w-4 cursor-text" />
         <Input
+          ref={inputRef}
           placeholder="Search blocks..."
           className="w-full pl-10 pr-3 py-2 border border-gray-200 dark:border-gray-700 rounded-md bg-gray-50 dark:bg-gray-800 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-600 focus:border-transparent"
           value={searchQuery}
           onChange={(e) => onSearchChange(e.target.value)}
+          onFocus={() => setSearchFocused(true)}
+          onBlur={() => setSearchFocused(false)}
         />
       </Label>
     </div>

--- a/frontend/src/routes/_workspace_layout.workflow-builder.($id)/route.tsx
+++ b/frontend/src/routes/_workspace_layout.workflow-builder.($id)/route.tsx
@@ -73,8 +73,6 @@ export default function WorkflowBuilder({
               workflowToEdit={workflowToEdit}
               onCollapseToggle={() => setBlockPanelOpen((open) => !open)}
               collapsed={!blockPanelOpen}
-              searchFocused={searchFocused}
-              setSearchFocused={setSearchFocused}
             />
             <Separator />
             <CanvasBody />

--- a/frontend/src/routes/_workspace_layout.workflow-builder.($id)/route.tsx
+++ b/frontend/src/routes/_workspace_layout.workflow-builder.($id)/route.tsx
@@ -9,7 +9,7 @@ import { Separator } from "@/components/ui/separator";
 import CanvasBody from "./CanvasBody";
 import CanvasHeader from "./CanvasHeader";
 import { workflowApi } from "@/api";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { cn } from "@/lib/utils";
 
 export async function loader({ params }: Route.LoaderArgs) {
@@ -28,6 +28,25 @@ export default function WorkflowBuilder({
   loaderData: workflowToEdit,
 }: Route.ComponentProps) {
   const [blockPanelOpen, setBlockPanelOpen] = useState(true);
+  const [searchFocused, setSearchFocused] = useState(false);
+
+  useEffect(() => {
+    const handleKeyPress = (e: KeyboardEvent) => {
+      const isTextInput =
+        e.target instanceof HTMLInputElement ||
+        e.target instanceof HTMLTextAreaElement;
+
+      if (e.key === "/" && !isTextInput) {
+        e.preventDefault();
+        setBlockPanelOpen(true);
+        setSearchFocused(true);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyPress);
+    return () => window.removeEventListener("keydown", handleKeyPress);
+  }, []);
+
   return (
     <div className="flex h-full">
       <ReactFlowProvider>
@@ -43,7 +62,10 @@ export default function WorkflowBuilder({
             <div
               className={`${blockPanelOpen ? "opacity-100" : "opacity-0 pointer-events-none"} transition-opacity duration-300 h-full`}
             >
-              <BlockPanel />
+              <BlockPanel
+                searchFocused={searchFocused}
+                setSearchFocused={setSearchFocused}
+              />
             </div>
           </div>
           <div className="flex-1 bg-slate-50 flex flex-col">
@@ -51,6 +73,8 @@ export default function WorkflowBuilder({
               workflowToEdit={workflowToEdit}
               onCollapseToggle={() => setBlockPanelOpen((open) => !open)}
               collapsed={!blockPanelOpen}
+              searchFocused={searchFocused}
+              setSearchFocused={setSearchFocused}
             />
             <Separator />
             <CanvasBody />


### PR DESCRIPTION
Whenever the user is on the 'Workflow Library' page and presses '/', the search in the block panel will open up. If the user needs to type in a '/' inside the search bar itself, there's no conflict. It also automatically opens the block panel if the user hits '/' while it's collapsed. 