### PR TITLE
add toasts to saving/updated workflows

### DIFF
--- a/frontend/src/routes/_workspace_layout.workflow-builder.($id)/CanvasHeader.tsx
+++ b/frontend/src/routes/_workspace_layout.workflow-builder.($id)/CanvasHeader.tsx
@@ -6,6 +6,7 @@ import { Input } from "@/components/ui/input";
 import { Menu } from "lucide-react";
 import { useReactFlow } from "@xyflow/react";
 import { useFlowStore } from "./flowStore";
+import { toast } from "sonner";
 
 export default function CanvasHeader({
   workflowToEdit,
@@ -77,6 +78,7 @@ export default function CanvasHeader({
                   target_node_id: edge.target,
                 })),
               });
+              toast.success("Workflow updated successfully");
             } else {
               workflowApi.createWorkflow({
                 name: name,
@@ -95,6 +97,7 @@ export default function CanvasHeader({
                   target_node_id: edge.target,
                 })),
               });
+              toast.success("Workflow saved successfully");
             }
           }}
         >

--- a/frontend/src/routes/_workspace_layout.workflow-builder.($id)/InspectorPanel/settings/email/index.tsx
+++ b/frontend/src/routes/_workspace_layout.workflow-builder.($id)/InspectorPanel/settings/email/index.tsx
@@ -1,8 +1,6 @@
 import { useForm, FormProvider } from "react-hook-form";
 import { EmailFormValues, emailFormSchema } from "./utils/emailValidation";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Toaster } from "@/components/ui/sonner";
-
 import { EmailForm } from "./EmailForm";
 import { EmailPreview } from "./EmailPreview";
 
@@ -31,8 +29,6 @@ export function EmailSettings() {
         <div className="flex justify-end"></div>
         <EmailPreview />
       </div>
-      {/* TODO: move this to global app component */}
-      <Toaster />
     </FormProvider>
   );
 }

--- a/frontend/src/routes/_workspace_layout/route.tsx
+++ b/frontend/src/routes/_workspace_layout/route.tsx
@@ -7,6 +7,7 @@ import { Outlet, redirect } from "react-router";
 import { getAuth } from "@clerk/react-router/ssr.server";
 import { Route } from "./+types/route";
 import { ReactFlowProvider } from "@xyflow/react";
+import { Toaster } from "@/components/ui/sonner";
 
 export async function loader(args: Route.LoaderArgs) {
   const { userId } = await getAuth(args);
@@ -19,6 +20,7 @@ export async function loader(args: Route.LoaderArgs) {
 export default function Layout() {
   return (
     <TooltipProvider>
+      <Toaster />
       <SidebarProvider>
         <div className="flex flex-col h-screen w-screen bg-slate-50">
           <Navbar />


### PR DESCRIPTION
- moved <Toaster/> to _workspace_library so toasts can be used anywhere we use this workspace 
- added toasts when a workflow is saved and updated
- the email inspector panel toasts are unaffected by this change, and still work as intended 